### PR TITLE
Added ability to disable webhook management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 -include Makefile.overrides
 
 MAISTRA_VERSION        ?= 2.1.0
-MAISTRA_BRANCH         ?= maistra-2.1
+MAISTRA_BRANCH         ?= ea314b69a97fde3102b758ff5dea592cf34c5713
 REPLACES_PRODUCT_CSV   ?= 2.0.3
 REPLACES_COMMUNITY_CSV ?= 2.0.3
 VERSION                ?= development

--- a/pkg/controller/common/config.go
+++ b/pkg/controller/common/config.go
@@ -24,6 +24,7 @@ type olm struct {
 	Images                    images `json:"relatedImage,omitempty"`
 	CNIDisabled               bool   `json:"cniEnabled,omitempty"`
 	WebhookManagementDisabled bool   `json:"webhookManagementDisabled,omitempty"`
+	SplitModeEnabled          bool   `json:"splitModeEnabled,omitempty"`
 }
 
 // Images for various versions

--- a/pkg/controller/common/config.go
+++ b/pkg/controller/common/config.go
@@ -21,8 +21,9 @@ type config struct {
 
 // OLM is intermediate struct for serialization
 type olm struct {
-	Images      images `json:"relatedImage,omitempty"`
-	CNIDisabled bool   `json:"cniEnabled,omitempty"`
+	Images                    images `json:"relatedImage,omitempty"`
+	CNIDisabled               bool   `json:"cniEnabled,omitempty"`
+	WebhookManagementDisabled bool   `json:"webhookManagementDisabled,omitempty"`
 }
 
 // Images for various versions

--- a/pkg/controller/servicemesh/webhookca/controller.go
+++ b/pkg/controller/servicemesh/webhookca/controller.go
@@ -3,6 +3,7 @@ package webhookca
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -231,6 +232,14 @@ type reconciler struct {
 // from the respective Istio SA secret or CA Bundle config map
 func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	logger := createLogger().WithValues("WebhookConfig", request.NamespacedName.String())
+
+	// If webhookmanagement is disabled, we do not want the CABUNDLE to be updated in the Reconcile loop
+	var webhookManagementDisabled = os.Getenv("OSDK_DISABLE_WEBHOOK_MANAGEMENT")
+	if webhookManagementDisabled == "true" {
+		logger.Info("WEBHOOK MANAGEMENT DISABLED IN RECONCILE LOOP")
+		return reconcile.Result{}, nil
+	}
+
 	logger.Info("reconciling WebhookConfiguration")
 	ctx := common.NewReconcileContext(logger)
 	return reconcile.Result{}, r.webhookCABundleManager.UpdateCABundle(ctx, r.Client, request.NamespacedName)

--- a/pkg/controller/servicemesh/webhookca/controller.go
+++ b/pkg/controller/servicemesh/webhookca/controller.go
@@ -3,7 +3,6 @@ package webhookca
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -60,10 +59,8 @@ var autoRegistrationMap = map[string]CABundleSource{
 // Add creates a new Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
-	// If webhookmanagement is disabled, we do not want the CABUNDLE to be updated in the Reconcile loop
-	var webhookManagementDisabled = os.Getenv("OSDK_DISABLE_WEBHOOK_MANAGEMENT")
-	if webhookManagementDisabled == "true" {
-		createLogger().Info("WEBHOOK MANAGEMENT DISABLED, not adding to watch list...")
+	if common.Config.OLM.WebhookManagementDisabled == true {
+		createLogger().Info("Webhook Config Management is disabled via olm configuration, not adding webhookca to watch list...")
 		return nil
 	}
 

--- a/pkg/controller/servicemesh/webhookca/controller.go
+++ b/pkg/controller/servicemesh/webhookca/controller.go
@@ -60,6 +60,13 @@ var autoRegistrationMap = map[string]CABundleSource{
 // Add creates a new Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
+	// If webhookmanagement is disabled, we do not want the CABUNDLE to be updated in the Reconcile loop
+	var webhookManagementDisabled = os.Getenv("OSDK_DISABLE_WEBHOOK_MANAGEMENT")
+	if webhookManagementDisabled == "true" {
+		createLogger().Info("WEBHOOK MANAGEMENT DISABLED, not adding to watch list...")
+		return nil
+	}
+
 	return add(mgr, newReconciler(mgr.GetClient(), mgr.GetScheme(), WebhookCABundleManagerInstance))
 }
 
@@ -232,14 +239,6 @@ type reconciler struct {
 // from the respective Istio SA secret or CA Bundle config map
 func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	logger := createLogger().WithValues("WebhookConfig", request.NamespacedName.String())
-
-	// If webhookmanagement is disabled, we do not want the CABUNDLE to be updated in the Reconcile loop
-	var webhookManagementDisabled = os.Getenv("OSDK_DISABLE_WEBHOOK_MANAGEMENT")
-	if webhookManagementDisabled == "true" {
-		logger.Info("WEBHOOK MANAGEMENT DISABLED IN RECONCILE LOOP")
-		return reconcile.Result{}, nil
-	}
-
 	logger.Info("reconciling WebhookConfiguration")
 	ctx := common.NewReconcileContext(logger)
 	return reconcile.Result{}, r.webhookCABundleManager.UpdateCABundle(ctx, r.Client, request.NamespacedName)

--- a/pkg/controller/servicemesh/webhooks/server.go
+++ b/pkg/controller/servicemesh/webhooks/server.go
@@ -1,8 +1,6 @@
 package webhooks
 
 import (
-	"os"
-
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -35,10 +33,8 @@ func Add(mgr manager.Manager) error {
 	ctx := common.NewContextWithLog(common.NewContext(), log)
 	log.Info("Configuring Maistra webhooks")
 
-	var webhookManagementDisabled = os.Getenv("OSDK_DISABLE_WEBHOOK_MANAGEMENT")
-	if webhookManagementDisabled == "true" {
-		log.Info("Webhook Resource Management is disabled via configuration")
-		//return nil
+	if common.Config.OLM.WebhookManagementDisabled == true {
+		log.Info("Webhook Config Management is disabled via olm configuration")
 	} else {
 		operatorNamespace := common.GetOperatorNamespace()
 		if err := createWebhookResources(ctx, mgr, log, operatorNamespace); err != nil {

--- a/pkg/controller/servicemesh/webhooks/server.go
+++ b/pkg/controller/servicemesh/webhooks/server.go
@@ -1,6 +1,8 @@
 package webhooks
 
 import (
+	"os"
+
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -33,9 +35,15 @@ func Add(mgr manager.Manager) error {
 	ctx := common.NewContextWithLog(common.NewContext(), log)
 	log.Info("Configuring Maistra webhooks")
 
-	operatorNamespace := common.GetOperatorNamespace()
-	if err := createWebhookResources(ctx, mgr, log, operatorNamespace); err != nil {
-		return err
+	var webhookManagementDisabled = os.Getenv("OSDK_DISABLE_WEBHOOK_MANAGEMENT")
+	if webhookManagementDisabled == "true" {
+		log.Info("Webhook Resource Management is disabled via configuration")
+		//return nil
+	} else {
+		operatorNamespace := common.GetOperatorNamespace()
+		if err := createWebhookResources(ctx, mgr, log, operatorNamespace); err != nil {
+			return err
+		}
 	}
 
 	watchNamespaceStr, err := k8sutil.GetWatchNamespace()

--- a/pkg/controller/servicemesh/webhooks/validation/controlplane.go
+++ b/pkg/controller/servicemesh/webhooks/validation/controlplane.go
@@ -46,7 +46,8 @@ func (v *ControlPlaneValidator) Handle(ctx context.Context, req admission.Reques
 		return admission.Allowed("")
 	}
 
-	if req.Namespace == common.GetOperatorNamespace() {
+	// TODO: Need switch for external/split control plane detection (Dataplane is in a different clustern than the operator)
+	if !common.Config.OLM.SplitModeEnabled && req.Namespace == common.GetOperatorNamespace() {
 		return validationFailedResponse(http.StatusBadRequest, metav1.StatusReasonBadRequest, fmt.Sprintf("service mesh may not be installed in the same project/namespace as the operator"))
 	}
 

--- a/pkg/controller/servicemesh/webhooks/validation/member.go
+++ b/pkg/controller/servicemesh/webhooks/validation/member.go
@@ -53,7 +53,8 @@ func (v *MemberValidator) Handle(ctx context.Context, req admission.Request) adm
 		return admission.Errored(http.StatusBadRequest, fmt.Errorf("ServiceMeshMember must be named %q", common.MemberName))
 	}
 
-	if smm.Namespace == common.GetOperatorNamespace() {
+	// TODO: Need switch for external/split control plane detection (Dataplane is in a different clustern than the operator)
+	if !common.Config.OLM.SplitModeEnabled && smm.Namespace == common.GetOperatorNamespace() {
 		return validationFailedResponse(http.StatusBadRequest, metav1.StatusReasonBadRequest, fmt.Sprintf("namespace where operator is installed cannot be added to any mesh"))
 	}
 

--- a/pkg/controller/servicemesh/webhooks/validation/memberroll.go
+++ b/pkg/controller/servicemesh/webhooks/validation/memberroll.go
@@ -78,7 +78,8 @@ func (v *MemberRollValidator) Handle(ctx context.Context, req admission.Request)
 		return validationFailedResponse(http.StatusBadRequest, metav1.StatusReasonBadRequest, fmt.Sprintf("ServiceMeshMemberRoll must be named '%s'", common.MemberRollName))
 	}
 
-	if smmr.Namespace == common.GetOperatorNamespace() {
+	// TODO: Need switch for external/split control plane detection (Dataplane is in a different clustern than the operator)
+	if !common.Config.OLM.SplitModeEnabled && smmr.Namespace == common.GetOperatorNamespace() {
 		return validationFailedResponse(http.StatusBadRequest, metav1.StatusReasonBadRequest, fmt.Sprintf("ServiceMeshMemberRoll may not be created in the same project/namespace as the operator"))
 	}
 


### PR DESCRIPTION
~~OSDK_DISABLE_WEBHOOK_MANAGEMENT enviroment variable should be set to "true", to enable manual configurable mutating and validating webhook configuration placements.~~
~~TODO:
CA control is yet to be done.~~

Added OLM configuration for disabling webhook management. Set **olm.webhookManagementDisabled: "true"** to enable this feature.

Also added olm config **olm.splitModeEnabled**. This tells the operator that the Dataplane is in a different cluster and should not throw errors via validating webhook logic eg. same namespace(but on different clusters)